### PR TITLE
[MainNet Followups] Move authorizations from `poktroll` and update the README

### DIFF
--- a/shannon/mainnet/README_Authorizations.md
+++ b/shannon/mainnet/README_Authorizations.md
@@ -1,0 +1,148 @@
+# POKTROLL Mainnet Genesis Setup <!-- omit in toc -->
+
+## Table of Contents <!-- omit in toc -->
+
+- [Identifying the necessary authorizations](#identifying-the-necessary-authorizations)
+  - [Cosmos SDK Messages](#cosmos-sdk-messages)
+  - [Pocket Network Messages](#pocket-network-messages)
+  - [Update the authorizations](#update-the-authorizations)
+- [Genesis Preparation](#genesis-preparation)
+  - [Generate Genesis](#generate-genesis)
+- [Generation `authz` authorizations](#generation-authz-authorizations)
+  - [Update DAO Reward Address](#update-dao-reward-address)
+  - [Export the genesis configuration](#export-the-genesis-configuration)
+
+## Identifying the necessary authorizations
+
+Use the following commands **to** see all the transactions available in the `Cosmos SDK` and `Pocket Network` modules.
+
+Identify the functions you need and update [pnf_authorizations.json](pnf_authorizations.json) and [grove_authorizations.json](grove_authorizations.json) with the necessary authorizations.
+
+The above requires a deep understanding of the protocol **which is** out of scope for this document.
+
+### Cosmos SDK Messages
+
+Identify all the messages available in the `Cosmos SDK` modules like so:
+
+```bash
+git clone https://github.com/cosmos/cosmos-sdk.git
+cd cosmos-sdk
+grep -r "message Msg" --include="*.proto" . | grep -v "Response" | sed -E 's/.*\/cosmos\/([^\/]+)\/[^:]+:message (Msg[^{]+).*/cosmos.\1.\2/' | sed 's/ {//' | grep "^cosmos\." | sort
+```
+
+Which will output
+
+```bash
+cosmos.accounts.MsgAuthenticate
+cosmos.accounts.MsgCreateProposal
+cosmos.accounts.MsgDelegate
+cosmos.accounts.MsgExecute
+cosmos.accounts.MsgExecuteBundle
+...
+```
+
+### Pocket Network Messages
+
+Identify all the messages available in the `Pocket Network` modules like so:
+
+```bash
+git clone git@github.com:pokt-network/poktroll.git
+cd poktroll
+grep -r "message Msg" --include="*.proto" . | grep -v "Response" | sed -E 's/.*\/poktroll\/([^\/]+)\/tx\.proto:message (Msg[^{]+).*/poktroll.\1.\2/' | sed 's/ {//' | grep "^poktroll\." | sort
+```
+
+Which will output
+
+```bash
+poktroll.application.MsgDelegateToGateway
+poktroll.application.MsgStakeApplication
+poktroll.application.MsgTransferApplication
+poktroll.application.MsgUndelegateFromGateway
+poktroll.application.MsgUnstakeApplication
+poktroll.application.MsgUpdateParam
+poktroll.application.MsgUpdateParams
+...
+```
+
+### Update the authorizations
+
+For each authorization you need, make sure to include a JSON object with the following structure:
+
+```json
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "poktREPLACE_THIS_WITH_THE_ADDRESS_THAT_SHOULD_GET_PERMISSION",
+    "authorization": {
+      "@type": "\/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "\/poktroll.service.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+```
+
+The above object contains the following fields:
+
+- `granter`: The onchain `x/gov` module address (`pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t`)
+- `grantee`: The address that should get permission
+- `authorization`: Enables authorization for `poktroll.service.MsgUpdateParams`
+- `expiration`: Expires in the year `2500`
+
+:::tip Recommended authorizations
+
+You can pass the lists from Pocket and Cosmos to an LLM of your choice and get a few suggestions
+
+:::
+
+## Genesis Preparation
+
+### Generate Genesis
+
+```bash
+# Where to save the files to
+export MAINNET_DIR=$HOME/pocket/tmp/mainnet
+
+# Make sure the dir is created
+mkdir -p $MAINNET_DIR
+
+# Make a note of the git sha you're on
+
+# Generate the genesis file and other important configuration files (first validator key, configs..)
+ignite chain init --skip-proto --check-dependencies --clear-cache --config=config_mainnet.yml --home=$MAINNET_DIR
+```
+
+## Generation `authz` authorizations
+
+```bash
+export PNF_ADDRESS=pokt_PNF_ADDRESS
+export GROVE_ADDRESS=pokt_GROVE_ADDRESS
+
+sed -i'' -e "s/ADD_PNF_ADDRESS_HERE/$PNF_ADDRESS/g" authorizations/pnf_authorizations.json
+sed -i'' -e "s/ADD_GROVE_ADDRESS_HERE/$GROVE_ADDRESS/g" authorizations/grove_authorizations.json
+
+jq --argjson authz "$(cat authorizations/pnf_authorizations.json)" \
+   '.app_state.authz.authorization = $authz' \
+   "$MAINNET_DIR/config/genesis.json" > tmp.json
+
+jq --argjson authz "$(cat authorizations/grove_authorizations.json)" \
+   '.app_state.authz.authorization += $authz' \
+   tmp.json > tmp2.json
+
+mv tmp2.json "$MAINNET_DIR/config/genesis.json"
+`rm tmp.json`
+```
+
+### Update DAO Reward Address
+
+```bash
+# use PNF_ADDRESS from previous snippet
+jq --arg addr "$PNF_ADDRESS" \
+   '.app_state.tokenomics.params.dao_reward_address = $addr' \
+   "$MAINNET_DIR/config/genesis.json" > tmp.json && \
+   mv tmp.json "$MAINNET_DIR/config/genesis.json"
+```
+
+### Export the genesis configuration
+
+```bash
+tar -czvf mainnet_backup.tar.gz $MAINNET_DIR
+```

--- a/shannon/mainnet/config_mainnet.yml
+++ b/shannon/mainnet/config_mainnet.yml
@@ -1,45 +1,3 @@
-# Pocket Network Shannon MainNet
-
-See the details in [pokt-network/poktroll/authorizations](https://github.com/pokt-network/poktroll/tree/main/authorizations)
-for details on how this was generated.
-
-## Pocket Network Shannon MainNet <!-- omit in toc -->
-
-- [Pocket Network Shannon MainNet](#pocket-network-shannon-mainnet)
-  - [Accounts](#accounts)
-  - [Seeds](#seeds)
-  - [Private keys](#private-keys)
-  - [Ignite config.yaml](#ignite-configyaml)
-    - [Preparation](#preparation)
-    - [Ignite config.yaml](#ignite-configyaml-1)
-
-## Accounts
-
-- **DAO/PNF**: `pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv`
-- **Validator1**: `poktvaloper12l2xmehtylf4m2vlddsxcgj3hlx8r6266pcaa3`
-- **Grove**: `pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh`
-
-## Seeds
-
-Currently supported list of seed nodes can be found in the [seeds](./seeds) file.
-
-## Private keys
-
-The MainNet is currently maintained by Grove.
-
-## Ignite config.yaml
-
-### Preparation
-
-See [this README](./README_Authorizations.md) for additional instructions and steps
-that were taken for MainNet preparation.
-
-### Ignite config.yaml
-
-The following [Ignite CLI](https://github.com/ignite/cli) config was used to
-generate the genesis file for MainNet.
-
-```yaml
 # This is a temporary config file that is used as a reference for the MainNet genesis generation. The content of this file
 # will be pushed to https://github.com/pokt-network/pocket-network-genesis/tree/master/shannon/mainnet along with genesis.json
 # and recommended configs.
@@ -316,4 +274,3 @@ genesis:
           supplier: 0.7 # Suppliers earn 70% of the global inflation during all claim settlements associated with the service they provide.
           source_owner: 0.1 # Service owners earn 10% of the global inflation during all claim settlements associated with their service.
           application: 0.0 # Application earns nothing from global inflation during all claim settlements.
-```

--- a/shannon/mainnet/grove_authorizations.json
+++ b/shannon/mainnet/grove_authorizations.json
@@ -1,0 +1,335 @@
+[
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.service.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.session.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.gateway.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.application.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.supplier.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.proof.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.tokenomics.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.shared.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.service.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.session.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.gateway.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.application.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.supplier.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.proof.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.tokenomics.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.shared.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.gateway.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.application.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.supplier.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.session.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.upgrade.v1beta1.MsgCancelUpgrade"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.auth.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.bank.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.distribution.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.mint.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.staking.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.slashing.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.gov.v1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.gov.v1.MsgCancelProposal"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.consensus.v1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.authz.v1beta1.MsgGrant"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.authz.v1beta1.MsgRevoke"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/pocket.migration.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.authz.v1beta1.MsgExec"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.authz.v1beta1.MsgRevokeAll"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.authz.v1beta1.MsgPruneExpiredGrants"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  }
+]

--- a/shannon/mainnet/pnf_authorizations.json
+++ b/shannon/mainnet/pnf_authorizations.json
@@ -1,0 +1,335 @@
+[
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.service.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.session.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.gateway.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.application.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.supplier.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.proof.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.tokenomics.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.shared.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.service.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.session.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.gateway.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.application.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.supplier.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.proof.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.tokenomics.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.shared.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.gateway.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.application.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.supplier.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.session.MsgUpdateParam"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.upgrade.v1beta1.MsgCancelUpgrade"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.auth.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.bank.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.distribution.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.mint.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.staking.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.slashing.v1beta1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.gov.v1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.gov.v1.MsgCancelProposal"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.consensus.v1.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.authz.v1beta1.MsgGrant"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.authz.v1beta1.MsgRevoke"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/poktroll.migration.MsgUpdateParams"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.authz.v1beta1.MsgExec"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.authz.v1beta1.MsgRevokeAll"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  },
+  {
+    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+    "grantee": "pokt1hv3xrylxvwd7hfv03j50ql0ttp3s5hqqelegmv",
+    "authorization": {
+      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+      "msg": "/cosmos.authz.v1beta1.MsgPruneExpiredGrants"
+    },
+    "expiration": "2500-01-01T00:00:00Z"
+  }
+]


### PR DESCRIPTION
## Summary

Add Shannon MainNet configuration files and authorization setup

### Primary Changes:
- Add the core `README.md` for Shannon MainNet with network details and account information
- Create configuration file `config_mainnet.yml` for genesis generation
- Set up authorization JSON files for PNF and Grove accounts

### Secondary changes:
- Add `README_Authorizations.md` with detailed setup instructions
- Configure genesis parameters including tokenomics and validator settings
- Define network governance structure with proper authorizations